### PR TITLE
Disable Develocity Build Cache in compilation tests

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -908,6 +908,10 @@ object Build {
           sjsSources
         } (Set(scalaJSIRSourcesJar)).toSeq
       }.taskValue,
+
+      // Develocity's Build Cache does not work with our compilation tests
+      // at the moment.
+      Test / develocityBuildCacheClient := None,
   )
 
   def insertClasspathInArgs(args: List[String], cp: String): List[String] = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,4 +22,4 @@ addSbtPlugin("ch.epfl.scala" % "sbt-tasty-mima" % "1.0.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.0")
 
-addSbtPlugin("com.gradle" % "sbt-develocity" % "1.0.1")
+addSbtPlugin("com.gradle" % "sbt-develocity" % "1.1.1")


### PR DESCRIPTION
At the moment, the Develocity Build Cache does not work properly with
our compilation tests, because the cache key does not take into account
the sources that are read in the tests. Keeping the build cache would
lead to false cache hits, so it is better to disable it for the time
being.
